### PR TITLE
Feature/error handling

### DIFF
--- a/kitchen-cloudbolt.gemspec
+++ b/kitchen-cloudbolt.gemspec
@@ -4,8 +4,8 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'kitchen-cloudbolt'
-  spec.version       = '1.3.0'
-  spec.date          = '2019-01-31'
+  spec.version       = '1.4.0'
+  spec.date          = '2019-03-15'
   spec.authors       = ['Adam Kinney']
   spec.email         = ['akinney@cloudbolt.io']
   spec.description   = 'Chef Test Kitchen Driver for CloudBolt'
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'test-kitchen', '~> 1.17'
-  spec.add_dependency 'cloudbolt', '0.0.4'
+  spec.add_dependency 'cloudbolt', '0.0.5'
 
   spec.add_development_dependency 'bundler', '~> 1.0'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/kitchen/driver/cloudbolt.rb
+++ b/lib/kitchen/driver/cloudbolt.rb
@@ -61,6 +61,8 @@ module Kitchen
       end
 
       def destroy(state)
+        return unless state[:server_id]
+        
         server_id = state[:server_id]
         server = connection.get_server(server_id)
         environment = server["_links"]["environment"]["href"]


### PR DESCRIPTION
This PR bumps the cloudbolt dependency to 0.0.5 (https://github.com/CloudBoltSoftware/cloudbolt-gem/pull/3) and also fixes a fatal error when running "Kitchen Test" or "Kitchen Destroy" when no machine exists.